### PR TITLE
CI: add new pr for ci stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+      - github-actions
 
 jobs:
   build-and-run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,14 @@ name: Test conda environment
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ master]
   pull_request:
-    branches: [ master ]
+    branches: [ master, github-actions ]
 
 jobs:
   build-and-run:
     name: Create conda environment with "envs/python3.8env.yml"
+    if: ${{ github.repository == 'slaclab/pythonEnvs' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Create and Pack environment
+
+on:
+  push:
+    branches:    
+      - master
+      - github-actions
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-and-run:
+    name: Create conda environment with "envs/python3.8env.yml"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8.8"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          environment-file: envs/python3.8env.yml
+          auto-activate-base: true
+          activate-environment: true
+          python-version: ${{ matrix.python-version }}
+      - name: Conda info
+        run: |
+          conda info
+          which python
+          conda list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,11 @@
-name: Create and Pack environment
+name: Test conda environment
 
 on:
+  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches:    
-      - master
-      - github-actions
+    branches: [ master ]
   pull_request:
-    branches:
-      - master
-      - github-actions
+    branches: [ master ]
 
 jobs:
   build-and-run:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+      - github-actions
 
 jobs:
   build-and-run:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -2,8 +2,7 @@ name: Test environment
 
 on:  
   push:
-    branches:
-      - master
+    types: [ opened, synchronize ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-run:
-    if: ${{ github.repository == 'slaclab/pythonEnvs' }}
+    name: Try conda environment with "envs/python3.8env.yml"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+    types: [ opened, synchronize ]
 
 jobs:
   build-and-run:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,18 +1,12 @@
 name: Test environment
 
 on:
-  push:
-    branches:    
-      - master
-      - github-actions
   pull_request:
-    branches:
-      - master
-      - github-actions
+    branches: [ master ]
 
 jobs:
   build-and-run:
-    name: Create conda environment with "envs/python3.8env.yml"
+    if: ${{ github.repository == 'slaclab/pythonEnvs' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -2,6 +2,8 @@ name: Test environment
 
 on:  
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,16 +1,17 @@
-name: Test conda environment
+name: Test environment
 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master]
+    branches:    
+      - master
+      - github-actions
   pull_request:
-    branches: [ master, github-actions ]
+    branches:
+      - master
 
 jobs:
   build-and-run:
     name: Create conda environment with "envs/python3.8env.yml"
-    if: ${{ github.repository == 'slaclab/pythonEnvs' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,8 +1,10 @@
 name: Test environment
 
-on:
+on:  
+  push:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build-and-run:


### PR DESCRIPTION
The old pr for CI integration is pointing to another fork copy of this repo, and it was just easier to create a new one instead.