### PR TITLE
CI: do not trigger CI on push - only on pull requests should be enoug…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,7 @@ name: CI - test conda environmnet
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
+  # Triggers the workflow on pull request events for master
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Trying the Github Action integration as well as taking off the trigger on push.